### PR TITLE
Fix invalid free of split child transaction data

### DIFF
--- a/src/DRAMSys/common/dramExtensions.cpp
+++ b/src/DRAMSys/common/dramExtensions.cpp
@@ -413,7 +413,11 @@ bool ParentExtension::notifyChildTransCompletion()
     {
         std::for_each(childTranses.begin(),
                       childTranses.end(),
-                      [](tlm::tlm_generic_payload* childTrans) { childTrans->release(); });
+                      [](tlm::tlm_generic_payload* childTrans)
+                      {
+                          childTrans->set_data_ptr(nullptr);
+                          childTrans->release();
+                      });
         childTranses.clear();
         return true;
     }

--- a/src/DRAMSys/controller/Controller.cpp
+++ b/src/DRAMSys/controller/Controller.cpp
@@ -112,7 +112,7 @@ Controller::Controller(const sc_module_name& name,
     gearing(config.gearing),
     windowSizeTime(simConfig.windowSize * memSpec.tCK),
     numberOfBeatsServed(memSpec.ranksPerChannel, 0),
-    memoryManager(simConfig.storageEnabled),
+    memoryManager(false),
     stats(*this)
 {
     if (simConfig.databaseRecording && tlmRecorder != nullptr)
@@ -780,7 +780,7 @@ void Controller::createChildTranses(tlm::tlm_generic_payload& parentTrans)
 
     for (unsigned childId = 0; childId < numChildTranses; childId++)
     {
-        tlm_generic_payload* childTrans = memoryManager.allocate();
+        tlm_generic_payload* childTrans = memoryManager.allocate(memSpec.maxDataBytesPerBurst);
         childTrans->acquire();
 
         // TODO:
@@ -790,7 +790,6 @@ void Controller::createChildTranses(tlm::tlm_generic_payload& parentTrans)
         // This problem solves itself when the transaction splitting is moved out of the controller.
         childTrans->set_command(parentTrans.get_command());
         childTrans->set_address(startAddress + childId * memSpec.maxBytesPerBurst);
-        childTrans->set_data_length(memSpec.maxDataBytesPerBurst);
         childTrans->set_data_ptr(startDataPtr + childId * memSpec.maxBytesPerBurst);
 
         ChildExtension::setExtension(*childTrans, parentTrans);


### PR DESCRIPTION
Hi, thanks for maintaining DRAMSys!

While integrating DRAMSys 5.6, I encountered an invalid free when processing
transactions larger than the maximum DRAM burst size.

## Problem

When storage is enabled and an incoming transaction is larger than
`maxBytesPerBurst`, `Controller::createChildTranses()` splits it into child
transactions.

Each child transaction borrows a slice of its parent transaction's data
buffer. However, the controller's `MemoryManager` is configured as owning
storage. During teardown, it therefore attempts to `delete[]` the borrowed
data pointer, resulting in:

```text
free(): invalid pointer
```

The child payload was also allocated from the zero-length pool but returned
to the burst-size pool, preventing it from being reused.

## Solution

- Configure the controller's child-transaction memory manager as non-owning.
- Allocate child payloads from the `maxDataBytesPerBurst` pool.
- Clear the borrowed data pointer before returning a child payload to the
  pool.
- Remove the now-redundant `set_data_length()` call.

The controller's memory manager is only used for child payloads; actual DRAM
contents remain managed through the configured backing store.

## Testing

Reproduced with `StoreMode: Store` and a transaction larger than
`maxBytesPerBurst`. Before this change, destroying DRAMSys aborted with
`free(): invalid pointer`. After this change, the simulation terminates
normally and child payloads are reused from the correct pool.

Thanks for reviewing this! Please let me know whether this approach fits
DRAMSys’s ownership model, or if you would prefer a different solution.